### PR TITLE
Init nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ Microcontrollers RP2350 and ESP32-S3 are designed to support secure environments
 
 ## Build for Raspberry Pico
 
+### Using CMake
+
 Before building, ensure you have installed the toolchain for the Pico and that the Pico SDK is properly located on your drive.
 
 ```
-git clone https://github.com/youruser/pico-fido2
+git clone https://github.com/librekeys/pico-fido2; cd pico-fido2
 git submodule update --init --recursive
-cd pico-fido2
 mkdir build
 cd build
 PICO_SDK_PATH=/path/to/pico-sdk cmake .. -DPICO_BOARD=board_type -DUSB_VID=0x1D50 -DUSB_PID=0x619B
@@ -113,7 +114,22 @@ After running `make`, the binary file `pico_fido2.uf2` will be generated. To loa
 3. Once the file is copied, the Pico mass storage device will automatically disconnect, and the Pico board will reset with the new firmware.
 4. A blinking LED will indicate that the device is ready to work.
 
-To configure your device you can use the [picoforge desktop application ](https://github.com/librekeys/picoforge).
+### Using Nix
+
+If you have Nix installed, you can build directly using the flake:
+
+```bash
+git clone https://github.com/librekeys/pico-fido2; cd pico-fido2
+# Build firmware
+nix build .#
+# Build with EdDSA support
+nix build .#pico-fido2-eddsa
+# firmware with VIDPID
+nix build .#pico-fido2-Yubikey5
+# Build with EdDSA support and VIDPID
+nix build .#pico-fido2-eddsa-Yubikey5
+# firmware will be located at ./result/pico_fido2.uf2
+```
 
 ## Drivers
 
@@ -125,4 +141,5 @@ This project is released under the GNU Affero General Public License v3 (AGPLv3)
 A copy of the AGPLv3 license is available in the `LICENSE` file.
 
 ## Credits
+
 This project uses libraries and portion of code from other projects that are detailed in the `LICENSE` file.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,241 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mbedtls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728898458,
+        "narHash": "sha256-CigOAezxk79SSTX6Z7rDnt64qI6nkCD0piY9ZVNy+e0=",
+        "owner": "Mbed-TLS",
+        "repo": "mbedtls",
+        "rev": "107ea89daaefb9867ea9121002fbbdf926780e98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mbed-TLS",
+        "repo": "mbedtls",
+        "rev": "107ea89daaefb9867ea9121002fbbdf926780e98",
+        "type": "github"
+      }
+    },
+    "mbedtls-eddsa": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1764521340,
+        "narHash": "sha256-a2edwKskmOKMy34xsD29OW/TlfHCn5PtUKDliDGUXi8=",
+        "owner": "polhenarejos",
+        "repo": "mbedtls",
+        "rev": "32604790a0433470ac1836be4faa1e0793035673",
+        "type": "github"
+      },
+      "original": {
+        "owner": "polhenarejos",
+        "ref": "mbedtls-3.6-eddsa",
+        "repo": "mbedtls",
+        "type": "github"
+      }
+    },
+    "mlkem": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768154581,
+        "narHash": "sha256-HCeoNOe/IKiUZ5v9f8mkv3Ftr4cKnKEQ85BpSgXo16M=",
+        "owner": "pq-code-package",
+        "repo": "mlkem-native",
+        "rev": "1453da5cd11ea6be7ae83d619d1a72b21e48ec7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pq-code-package",
+        "repo": "mlkem-native",
+        "rev": "1453da5cd11ea6be7ae83d619d1a72b21e48ec7d",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pico-fido": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767639369,
+        "narHash": "sha256-Jfnl9iz9QcQUbjMHfbNzEH/R3aLcVbCPMC999hGa3J4=",
+        "owner": "librekeys",
+        "repo": "pico-fido",
+        "rev": "81d97f1a18856f73b0ffed50afeaf735cc2c1a54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "librekeys",
+        "repo": "pico-fido",
+        "rev": "81d97f1a18856f73b0ffed50afeaf735cc2c1a54",
+        "type": "github"
+      }
+    },
+    "pico-fido2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768493135,
+        "narHash": "sha256-CiijN//MpBBkP4OEtvEhuHGJUvDqocX/5+Aa3aShil0=",
+        "owner": "librekeys",
+        "repo": "pico-fido2",
+        "rev": "75f50213998c325379d563f5736262276d3badbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "librekeys",
+        "repo": "pico-fido2",
+        "rev": "75f50213998c325379d563f5736262276d3badbd",
+        "type": "github"
+      }
+    },
+    "pico-keys-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767639058,
+        "narHash": "sha256-9CTgH1e8+Roa1XJnocxBsudOa3AkHrtS80FcOZWBFHU=",
+        "owner": "librekeys",
+        "repo": "pico-keys-sdk",
+        "rev": "263e554cc6c59a5f168f8589c4bdabe6e1e64c25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "librekeys",
+        "repo": "pico-keys-sdk",
+        "rev": "263e554cc6c59a5f168f8589c4bdabe6e1e64c25",
+        "type": "github"
+      }
+    },
+    "pico-openpgp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767639221,
+        "narHash": "sha256-Bhbrobc+P9ZR6gz4v22XfJ+ymANHT2i8HHpZT4Fp464=",
+        "owner": "librekeys",
+        "repo": "pico-openpgp",
+        "rev": "822038aba29219e2fb48376a3ca2c1eb1af03059",
+        "type": "github"
+      },
+      "original": {
+        "owner": "librekeys",
+        "repo": "pico-openpgp",
+        "rev": "822038aba29219e2fb48376a3ca2c1eb1af03059",
+        "type": "github"
+      }
+    },
+    "pico-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753763866,
+        "narHash": "sha256-hQdEZD84/cnLSzP5Xr9vbOGROQz4BjeVOnvbyhe6rfM=",
+        "owner": "raspberrypi",
+        "repo": "pico-sdk",
+        "rev": "a1438dff1d38bd9c65dbd693f0e5db4b9ae91779",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "2.2.0",
+        "repo": "pico-sdk",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mbedtls": "mbedtls",
+        "mbedtls-eddsa": "mbedtls-eddsa",
+        "mlkem": "mlkem",
+        "nixpkgs": "nixpkgs",
+        "pico-fido": "pico-fido",
+        "pico-fido2": "pico-fido2",
+        "pico-keys-sdk": "pico-keys-sdk",
+        "pico-openpgp": "pico-openpgp",
+        "pico-sdk": "pico-sdk",
+        "tinycbor": "tinycbor",
+        "tinyusb": "tinyusb"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinycbor": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741743135,
+        "narHash": "sha256-JgkZAvZ63jjTdFRnyk+AeIWcGsg36UtPPFbhFjky9e8=",
+        "owner": "intel",
+        "repo": "tinycbor",
+        "rev": "c0aad2fb2137a31b9845fbaae3653540c410f215",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intel",
+        "repo": "tinycbor",
+        "rev": "c0aad2fb2137a31b9845fbaae3653540c410f215",
+        "type": "github"
+      }
+    },
+    "tinyusb": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1735105509,
+        "narHash": "sha256-h2/OaZ5wVPUOg7uJ0b+J0Feq8V/NuhW2UWsUWpefgsc=",
+        "owner": "hathach",
+        "repo": "tinyusb",
+        "rev": "86ad6e56c1700e85f1c5678607a762cfe3aa2f47",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hathach",
+        "repo": "tinyusb",
+        "rev": "86ad6e56c1700e85f1c5678607a762cfe3aa2f47",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,216 @@
+{
+  description = "Pico FIDO2 - FIDO2/OpenPGP firmware for Raspberry Pi Pico";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    pico-sdk = {
+      url = "github:raspberrypi/pico-sdk/2.2.0";
+      flake = false;
+    };
+    tinyusb = {
+      url = "github:hathach/tinyusb/86ad6e56c1700e85f1c5678607a762cfe3aa2f47";
+      flake = false;
+    };
+
+    pico-fido2 = {
+      url = "github:librekeys/pico-fido2/75f50213998c325379d563f5736262276d3badbd";
+      flake = false;
+    };
+    pico-openpgp = {
+      url = "github:librekeys/pico-openpgp/822038aba29219e2fb48376a3ca2c1eb1af03059";
+      flake = false;
+    };
+    pico-fido = {
+      url = "github:librekeys/pico-fido/81d97f1a18856f73b0ffed50afeaf735cc2c1a54";
+      flake = false;
+    };
+    pico-keys-sdk = {
+      url = "github:librekeys/pico-keys-sdk/263e554cc6c59a5f168f8589c4bdabe6e1e64c25";
+      flake = false;
+    };
+
+    mbedtls = {
+      url = "github:Mbed-TLS/mbedtls/107ea89daaefb9867ea9121002fbbdf926780e98";
+      flake = false;
+    };
+    mbedtls-eddsa = {
+      url = "github:polhenarejos/mbedtls/mbedtls-3.6-eddsa";
+      flake = false;
+    };
+    tinycbor = {
+      url = "github:intel/tinycbor/c0aad2fb2137a31b9845fbaae3653540c410f215";
+      flake = false;
+    };
+    mlkem = {
+      url = "github:pq-code-package/mlkem-native/1453da5cd11ea6be7ae83d619d1a72b21e48ec7d";
+      flake = false;
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    pico-sdk,
+    tinyusb,
+    pico-fido2,
+    pico-fido,
+    pico-openpgp,
+    pico-keys-sdk,
+    mbedtls,
+    mbedtls-eddsa,
+    tinycbor,
+    mlkem,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+
+        picoSdk = pkgs.stdenvNoCC.mkDerivation {
+          name = "pico-sdk-full";
+          dontUnpack = true;
+          dontFixup = true;
+          installPhase = ''
+            cp -r ${pico-sdk} $out
+            chmod -R u+w $out
+            rm -rf $out/lib/tinyusb
+            cp -r ${tinyusb} $out/lib/tinyusb
+          '';
+        };
+
+        buildTools = with pkgs; [
+          cmake
+          gcc-arm-embedded
+          python3
+          picotool
+        ];
+
+        mkPicoFido2 = {
+          pname,
+          mbedtlsSrc,
+          product ? null,
+          extraCmakeFlags ? [],
+          extraDescription ? "",
+        }: let
+          vidpidFlag = pkgs.lib.optionals (product != null) [
+            "-DVIDPID=${product}"
+          ];
+        in
+          pkgs.stdenvNoCC.mkDerivation {
+            inherit pname;
+            version = "7.2-4.2";
+
+            src = pico-fido2;
+
+            dontFixup = true;
+
+            nativeBuildInputs = buildTools;
+
+            postUnpack = ''
+              chmod -R u+w $sourceRoot
+
+              rm -rf $sourceRoot/pico-fido
+              cp -r ${pico-fido} $sourceRoot/pico-fido
+
+              rm -rf $sourceRoot/pico-openpgp
+              cp -r ${pico-openpgp} $sourceRoot/pico-openpgp
+
+              rm -rf $sourceRoot/pico-keys-sdk
+              mkdir -p $sourceRoot/pico-keys-sdk
+              cp -r ${pico-keys-sdk}/* $sourceRoot/pico-keys-sdk/
+              chmod -R u+w $sourceRoot/pico-keys-sdk
+
+              rm -rf $sourceRoot/pico-keys-sdk/mbedtls
+              cp -r ${mbedtlsSrc} $sourceRoot/pico-keys-sdk/mbedtls
+
+              rm -rf $sourceRoot/pico-keys-sdk/tinycbor
+              cp -r ${tinycbor} $sourceRoot/pico-keys-sdk/tinycbor
+
+              rm -rf $sourceRoot/pico-keys-sdk/mlkem
+              cp -r ${mlkem} $sourceRoot/pico-keys-sdk/mlkem
+
+              chmod -R u+w $sourceRoot
+            '';
+
+            configurePhase = ''
+              cmake -S . -B build \
+                -DPICO_SDK_PATH=${picoSdk} \
+                -DPICO_BOARD=pico2 \
+                -DCMAKE_BUILD_TYPE=MinSizeRel \
+                ${pkgs.lib.concatStringsSep " \\\n              " (extraCmakeFlags ++ vidpidFlag)}
+            '';
+
+            buildPhase = ''
+              cmake --build build -j$NIX_BUILD_CORES
+            '';
+
+            installPhase = ''
+              mkdir -p $out
+              cp build/pico_fido2*.uf2 $out/
+            '';
+
+            meta = with pkgs.lib; {
+              description = "FIDO2/OpenPGP firmware for Raspberry Pi Pico${extraDescription}";
+              homepage = "https://github.com/sst311212/pico-fido2";
+              license = licenses.gpl3Only;
+              platforms = platforms.all;
+            };
+          };
+      in let
+        products = [
+          "NitroHSM"
+          "NitroFIDO2"
+          "NitroStart"
+          "NitroPro"
+          "Nitro3"
+          "Yubikey5"
+          "YubikeyNeo"
+          "YubiHSM"
+          "Gnuk"
+          "GnuPG"
+        ];
+      in {
+        packages =
+          {
+            pico-fido2 = mkPicoFido2 {
+              pname = "pico-fido2";
+              mbedtlsSrc = mbedtls;
+            };
+
+            # NOTE https://github.com/polhenarejos/pico-openpgp/releases/tag/v4.0-eddsa1
+            # Important: EdDSA cannot work in ESP32, since Espressif uses its own MbedTLS fork.
+            # This is an experimental release. It adds support for EdDSA with Ed25519 and Ed448 curves.
+            # Since EdDSA is not officially approved by MbedTLS, it is considered experimental and in beta stage. Though it is deeply tested, it might contain bugs.
+            # Use with caution.
+            pico-fido2-eddsa = mkPicoFido2 {
+              pname = "pico-fido2-eddsa";
+              mbedtlsSrc = mbedtls-eddsa;
+              extraCmakeFlags = ["-DENABLE_EDDSA=ON"];
+              extraDescription = " (with experimental EdDSA support)";
+            };
+          }
+          // pkgs.lib.genAttrs (map (f: "pico-fido2-${f}") products) (f:
+            mkPicoFido2 {
+              pname = "pico-fido2-${f}";
+              mbedtlsSrc = mbedtls;
+              product = f;
+            })
+          // pkgs.lib.genAttrs (map (f: "pico-fido2-eddsa-${f}") products) (f:
+            mkPicoFido2 {
+              pname = "pico-fido2-eddsa-${f}";
+              mbedtlsSrc = mbedtls-eddsa;
+              product = f;
+              extraCmakeFlags = ["-DENABLE_EDDSA=ON"];
+              extraDescription = " (with experimental EdDSA support)";
+            });
+
+        defaultPackage = self.packages.${system}.pico-fido2;
+
+        devShells.default = pkgs.mkShell {
+          packages = buildTools;
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

Add flake.nix to build pico-fido2 firmware, fix https://github.com/librekeys/pico-fido2/issues/1


## Details / Impact

Please include any relevant details:

- Tested on Tenstar RP2350
- Firmware 7.4 with pico gpg https://github.com/polhenarejos/pico-openpgp/tree/0b7beeec8cf968b632126a6e7f091b3b5c08724e
- Behavior changes:
  - IDK if it's was the case before, but on linux, alternating from fido and gpg make the key buggy and force a key reset


## Testing

How did you test this change?

To build the 'default' image:
- `nix build .#`
To build the eddsa' image:
- `nix build .#pico-fido2-eddsa`

## Licensing confirmation (required)

By checking the box below, you confirm ALL of the following:

- You are the author of this contribution, or you have the right to contribute it.
- You have read `CONTRIBUTING.md`.
- You agree that this contribution may be merged, used, modified, and redistributed:
  - under the AGPLv3 Community Edition, **and**
  - under any proprietary / commercial / Enterprise editions of this project,
    now or in the future.
- You understand that submitting this PR does not create any support obligation,
  SLA, or guarantee of merge.

**I confirm the above licensing terms:**

- [x] Yes, I agree

## Anything else?

This flake fetch all src via fixed inputs